### PR TITLE
cmake: minimal version to 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.16)
 
 #
 # SpadesX


### PR DESCRIPTION
This is needed for distros that do not have cmake 3.17 yet (Seriously WTF are you doing using 3.16 still Ubuntu and others ? Stability is one thing but 3.16 is nearly ancient now. Cmake 3.20 is freaking out)