### PR TITLE
Add fallbacks for the config variables that can't be found in the config file

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,5 +4,6 @@ Haxk20
 Rakete
 CircumScriptor
 xtreme8000
+rndtrash
 
 If you commited to SpadesX please also add yourself to this file.

--- a/Source/Main.c
+++ b/Source/Main.c
@@ -3,6 +3,7 @@
 #include "Structs.h"
 
 #include <Types.h>
+#include <JSONHelpers.h>
 #include <json-c/json.h>
 #include <json-c/json_object.h>
 #include <stdio.h>
@@ -10,99 +11,43 @@
 
 int main(void)
 {
-    uint16 port   = DEFAULT_SERVER_PORT;
-    uint8  master = 1;
+    uint16 port;
+    uint8  master;
+    uint8  gamemode;
+    const char* managerPasswd;
+    const char* adminPasswd;
+    const char* modPasswd;
+    const char* guardPasswd;
+    const char* trustedPasswd;
+    const char* serverName;
+    const char* team1Name;
+    const char* team2Name;
+    uint8       team1Color[3];
+    uint8       team2Color[3];
 
     struct json_object* parsed_json;
-    struct json_object* portInConfig;
-    struct json_object* masterInConfig;
     struct json_object* mapInConfig;
-    struct json_object* managerPasswdInConfig;
-    struct json_object* adminPasswdInConfig;
-    struct json_object* modPasswdInConfig;
-    struct json_object* guardPasswdInConfig;
-    struct json_object* trustedPasswdInConfig;
-    struct json_object* serverNameInConfig;
-    struct json_object* team1NameInConfig;
-    struct json_object* team2NameInConfig;
-    struct json_object* team1ColorInConfig;
-    struct json_object* team2ColorInConfig;
-    struct json_object* gamemodeInConfig;
 
     parsed_json = json_object_from_file("config.json");
-    if (json_object_object_get_ex(parsed_json, "port", &portInConfig) == 0) {
-        printf("Failed to find port number in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "master", &masterInConfig) == 0) {
-        printf("Failed to find master variable in config\n");
-        return -1;
-    }
+    READ_INT_FROM_JSON(parsed_json, port, port, "port number", DEFAULT_SERVER_PORT)
+    READ_INT_FROM_JSON(parsed_json, master, master, "master variable", 1)
+    READ_INT_FROM_JSON(parsed_json, gamemode, gamemode, "gamemode", 0)
     if (json_object_object_get_ex(parsed_json, "map", &mapInConfig) == 0) {
         printf("Failed to find map name in config\n");
         return -1;
     }
-    if (json_object_object_get_ex(parsed_json, "manager_password", &managerPasswdInConfig) == 0) {
-        printf("Failed to find manager password in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "admin_password", &adminPasswdInConfig) == 0) {
-        printf("Failed to find admin password in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "moderator_password", &modPasswdInConfig) == 0) {
-        printf("Failed to find moderator password in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "guard_password", &guardPasswdInConfig) == 0) {
-        printf("Failed to find guard password in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "trusted_password", &trustedPasswdInConfig) == 0) {
-        printf("Failed to find trusted password in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "server_name", &serverNameInConfig) == 0) {
-        printf("Failed to find server name in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "team1_name", &team1NameInConfig) == 0) {
-        printf("Failed to find team1 name in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "team2_name", &team2NameInConfig) == 0) {
-        printf("Failed to find team2 name in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "team1_color", &team1ColorInConfig) == 0) {
-        printf("Failed to find team1 color in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "team2_color", &team2ColorInConfig) == 0) {
-        printf("Failed to find team2 color in config\n");
-        return -1;
-    }
-    if (json_object_object_get_ex(parsed_json, "gamemode", &gamemodeInConfig) == 0) {
-        printf("Failed to find gamemode in config\n");
-        return -1;
-    }
-    port                      = json_object_get_int(portInConfig);
-    master                    = json_object_get_int(masterInConfig);
-    const char* managerPasswd = json_object_get_string(managerPasswdInConfig);
-    const char* adminPasswd   = json_object_get_string(adminPasswdInConfig);
-    const char* modPasswd     = json_object_get_string(modPasswdInConfig);
-    const char* guardPasswd   = json_object_get_string(guardPasswdInConfig);
-    const char* trustedPasswd = json_object_get_string(trustedPasswdInConfig);
-    const char* serverName    = json_object_get_string(serverNameInConfig);
-    const char* team1Name     = json_object_get_string(team1NameInConfig);
-    const char* team2Name     = json_object_get_string(team2NameInConfig);
-    uint8       team1Color[3];
-    uint8       team2Color[3];
-    uint8       gamemode = json_object_get_int(gamemodeInConfig);
-    for (int i = 0; i < 3; ++i) {
-        team1Color[i] = json_object_get_int(json_object_array_get_idx(team1ColorInConfig, i));
-        team2Color[i] = json_object_get_int(json_object_array_get_idx(team2ColorInConfig, i));
-    }
+    READ_STR_FROM_JSON(parsed_json, managerPasswd, manager_password, "manager password", "")
+    READ_STR_FROM_JSON(parsed_json, adminPasswd, admin_password, "admin password", "")
+    READ_STR_FROM_JSON(parsed_json, modPasswd, moderator_password, "moderator password", "")
+    READ_STR_FROM_JSON(parsed_json, guardPasswd, guard_password, "guard password", "")
+    READ_STR_FROM_JSON(parsed_json, trustedPasswd, trusted_password, "trusted password", "")
+    READ_STR_FROM_JSON(parsed_json, serverName, server_name, "server name", "SpadesX Server")
+    READ_STR_FROM_JSON(parsed_json, team1Name, team1_name, "team1 name", "Blue")
+    READ_STR_FROM_JSON(parsed_json, team2Name, team2_name, "team2 name", "Red")
+    // array requires additional pair of parentheses because of how macros work in C
+    READ_INT_ARR_FROM_JSON(parsed_json, team1Color, team1_color, "team1 color", ((uint8[]){0, 0, 255}), 3)
+    READ_INT_ARR_FROM_JSON(parsed_json, team2Color, team2_color, "team2 color", ((uint8[]){255, 0, 0}), 3)
+
     uint8 mapArrayLen = json_object_array_length(mapInConfig);
     char  mapArray[mapArrayLen][64];
 

--- a/Source/Server.c
+++ b/Source/Server.c
@@ -15,6 +15,7 @@
 #include <Line.h>
 #include <Queue.h>
 #include <Types.h>
+#include <JSONHelpers.h>
 #include <enet/enet.h>
 #include <json-c/json.h>
 #include <json-c/json_object.h>
@@ -141,48 +142,18 @@ static void ServerInit(Server*     server,
     struct json_object* parsed_map_json;
     parsed_map_json = json_object_from_file(mapConfig);
 
-    struct json_object* team1StartInConfig;
-    struct json_object* team1EndInConfig;
-    struct json_object* team2StartInConfig;
-    struct json_object* team2EndInConfig;
-    struct json_object* authorInConfig;
-    int                 team1Start[3];
-    int                 team2Start[3];
-    int                 team1End[3];
-    int                 team2End[3];
+    int          team1Start[3];
+    int          team2Start[3];
+    int          team1End[3];
+    int          team2End[3];
+    const char * author;
 
-    if (json_object_object_get_ex(parsed_map_json, "team1_start", &team1StartInConfig) == 0) {
-        LOG_ERROR("Failed to find team1 start in map config");
-        server->running = 0;
-        return;
-    }
-    if (json_object_object_get_ex(parsed_map_json, "team1_end", &team1EndInConfig) == 0) {
-        LOG_ERROR("Failed to find team1 end in map config");
-        server->running = 0;
-        return;
-    }
-    if (json_object_object_get_ex(parsed_map_json, "team2_start", &team2StartInConfig) == 0) {
-        LOG_ERROR("Failed to find team2 start in map config");
-        server->running = 0;
-        return;
-    }
-    if (json_object_object_get_ex(parsed_map_json, "team2_end", &team2EndInConfig) == 0) {
-        LOG_ERROR("Failed to find team2 start in map config");
-        server->running = 0;
-        return;
-    }
-    if (json_object_object_get_ex(parsed_map_json, "author", &authorInConfig) == 0) {
-        LOG_ERROR("Failed to find author in map config");
-        server->running = 0;
-        return;
-    }
-
-    for (uint8 i = 0; i < 2; ++i) {
-        team1Start[i] = json_object_get_int(json_object_array_get_idx(team1StartInConfig, i));
-        team2Start[i] = json_object_get_int(json_object_array_get_idx(team2StartInConfig, i));
-        team1End[i]   = json_object_get_int(json_object_array_get_idx(team1EndInConfig, i));
-        team2End[i]   = json_object_get_int(json_object_array_get_idx(team2EndInConfig, i));
-    }
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team1Start, team1_start, "team1 start", ((int[]){0, 0, 0}), 3)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team1End, team1_end, "team1 end", ((int[]){10, 10, 10}), 3)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team2Start, team2_start, "team2 start", ((int[]){20, 20, 0}), 3)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team2End, team2_end, "team2 end", ((int[]){20, 20, 10}), 3)
+    READ_STR_FROM_JSON(parsed_map_json, author, author, "author", "Unknown")
+    (void) author;
 
     json_object_put(parsed_map_json);
 

--- a/Source/Server.c
+++ b/Source/Server.c
@@ -142,16 +142,16 @@ static void ServerInit(Server*     server,
     struct json_object* parsed_map_json;
     parsed_map_json = json_object_from_file(mapConfig);
 
-    int          team1Start[3];
-    int          team2Start[3];
-    int          team1End[3];
-    int          team2End[3];
+    int          team1Start[2];
+    int          team2Start[2];
+    int          team1End[2];
+    int          team2End[2];
     const char * author;
 
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team1Start, team1_start, "team1 start", ((int[]){0, 0, 0}), 3)
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team1End, team1_end, "team1 end", ((int[]){10, 10, 10}), 3)
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team2Start, team2_start, "team2 start", ((int[]){20, 20, 0}), 3)
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team2End, team2_end, "team2 end", ((int[]){20, 20, 10}), 3)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team1Start, team1_start, "team1 start", ((int[]){0, 0}), 2)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team1End, team1_end, "team1 end", ((int[]){10, 10}), 2)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team2Start, team2_start, "team2 start", ((int[]){20, 20}), 2)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team2End, team2_end, "team2 end", ((int[]){30, 30}), 2)
     READ_STR_FROM_JSON(parsed_map_json, author, author, "author", "Unknown")
     (void) author;
 
@@ -170,17 +170,13 @@ static void ServerInit(Server*     server,
 
     server->protocol.spawns[0].from.x = team1Start[0];
     server->protocol.spawns[0].from.y = team1Start[1];
-    server->protocol.spawns[0].from.z = team1Start[2];
     server->protocol.spawns[0].to.x   = team1End[0];
     server->protocol.spawns[0].to.y   = team1End[1];
-    server->protocol.spawns[0].to.z   = team1End[2];
 
     server->protocol.spawns[1].from.x = team2Start[0];
     server->protocol.spawns[1].from.y = team2Start[1];
-    server->protocol.spawns[1].from.z = team2Start[2];
     server->protocol.spawns[1].to.x   = team2End[0];
     server->protocol.spawns[1].to.y   = team2End[1];
-    server->protocol.spawns[1].to.z   = team2End[2];
 
     server->protocol.colorFog.colorArray[0] = 0x80;
     server->protocol.colorFog.colorArray[1] = 0xE8;

--- a/Source/Util/JSONHelpers.h
+++ b/Source/Util/JSONHelpers.h
@@ -1,0 +1,21 @@
+#ifndef JSONHELPERS_H
+#define JSONHELPERS_H
+
+#define READ_VAR_FROM_JSON(type, fmt, pj, var, jsonvar, description, fallback) {\
+    struct json_object* _ ## var; \
+    if (!json_object_object_get_ex(pj, #jsonvar, &_ ## var)){ \
+    LOG_WARNING("Failed to find " description " in config, falling back to " fmt, fallback); \
+    var = fallback; \
+    } else var = json_object_get_ ## type (_ ## var);}
+
+#define READ_INT_FROM_JSON(pj, var, jsonvar, description, fallback) READ_VAR_FROM_JSON(int, "%i", pj, var, jsonvar, description, fallback)
+#define READ_STR_FROM_JSON(pj, var, jsonvar, description, fallback) READ_VAR_FROM_JSON(string, "\"%s\"", pj, var, jsonvar, description, fallback)
+
+#define READ_INT_ARR_FROM_JSON(pj, var, jsonvar, description, fallback, fbsize) {\
+    struct json_object* _ ## var; \
+    if (!json_object_object_get_ex(pj, #jsonvar, &_ ## var)){ \
+    LOG_WARNING("Failed to find " description " in config, falling back to " #fallback); \
+    for (int i = 0; i < fbsize; ++i) var[i] = fallback[i]; \
+    } else for (int i = 0; i < fbsize; ++i) var[i] = json_object_get_int(json_object_array_get_idx(_ ## var, i));}
+
+#endif

--- a/Source/Util/Types.h
+++ b/Source/Util/Types.h
@@ -2,9 +2,9 @@
 #ifndef TYPES_H
 #define TYPES_H
 
-#define LOG_STATUS(msg)  printf("STATUS: " msg "\n")
-#define LOG_WARNING(msg) printf("WARNING: " msg "\n")
-#define LOG_ERROR(msg)   fprintf(stderr, "ERROR: " msg "\n")
+#define LOG_STATUS(msg, ...)  printf("STATUS: " msg "\n", ##__VA_ARGS__)
+#define LOG_WARNING(msg, ...) printf("WARNING: " msg "\n", ##__VA_ARGS__)
+#define LOG_ERROR(msg, ...)   fprintf(stderr, "ERROR: " msg "\n", ##__VA_ARGS__)
 
 typedef unsigned char          uint8;
 typedef unsigned short         uint16;


### PR DESCRIPTION
Made these changes before I found out that the config file together with map are located in the source directory, though they aren't copied to the build directory. What a dumbass!

Anyway, I think that having a fallback for the config values is a great feature.

Also, while rewriting config reading routines, I've found these lines of code: 

https://github.com/SpadesX/SpadesX/blob/9a5b9f10d8f13c0e0f5910f2d92d8dc8660cf304/Source/Server.c#L180-L185

Is it supposed to read only 2 elements from the 3 element array? Or is it just me having an amount of braincells that is roughly equal to the size of said arrays?