### PR TITLE
PacketManager.c: Change SMG delay to 100ms

### DIFF
--- a/Source/Server/Packets/PacketManager.c
+++ b/Source/Server/Packets/PacketManager.c
@@ -27,7 +27,7 @@ inline uint8_t allow_shot(server_t*  server,
          (player->item == 2 && player->weapon == 0 &&
           diff_is_older_then(time_now, &player->timers.since_last_shot, NANO_IN_MILLI * 500)) ||
          (player->item == 2 && player->weapon == 1 &&
-          diff_is_older_then(time_now, &player->timers.since_last_shot, NANO_IN_MILLI * 110)) ||
+          diff_is_older_then(time_now, &player->timers.since_last_shot, NANO_IN_MILLI * 100)) ||
          (player->item == 2 && player->weapon == 2 &&
           diff_is_older_then(time_now, &player->timers.since_last_shot, NANO_IN_MILLI * 1000))) &&
         player->alive && player_hit->alive && (player->team != player_hit->team || player->allow_team_killing) &&


### PR DESCRIPTION
The SMG delay was set to 110ms, which is incorrect. It should be 100ms as seen on [OpenSpades](https://github.com/yvt/openspades/blob/f141208322953a4473eb42019c578e87a8a36640/Sources/Client/Weapon.cpp#L231) and [BetterSpades](https://github.com/xtreme8000/BetterSpades/blob/f83760ec1ae4dff58b8ad04109c3e7c6d562e2c8/src/weapon.c#L103).