### PR TITLE
Add JetBrains and CMake Debug files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 #
 
 [Bb]uild
+cmake-build-debug/
 
 #
 # Editor
@@ -12,3 +13,4 @@
 .vscode
 workspace.code-workspace
 compile_commands.json
+.idea


### PR DESCRIPTION
Adds the `.idea` directory and CMake debug files to gitignore. 