### PR TITLE
Temporary fix for weapon/spade BlockAction delay

### DIFF
--- a/Source/Server/Packets/BlockAction.c
+++ b/Source/Server/Packets/BlockAction.c
@@ -140,7 +140,7 @@ void receive_block_action(server_t* server, player_t* player, stream_t* data)
                                     } else if (player->weapon == 0 &&
                                                diff_is_older_then(timeNow,
                                                                   &player->timers.since_last_block_dest_with_gun,
-                                                                  ((RIFLE_DELAY * 2) - (NANO_IN_MILLI * 10))) == 0)
+                                                                  (RIFLE_DELAY - (NANO_IN_MILLI * 10))) == 0)
                                     {
                                         send_message_to_staff(server,
                                                               "Player %s (#%hhu) probably has rapid shooting hack",
@@ -150,7 +150,7 @@ void receive_block_action(server_t* server, player_t* player, stream_t* data)
                                     } else if (player->weapon == 1 &&
                                                diff_is_older_then(timeNow,
                                                                   &player->timers.since_last_block_dest_with_gun,
-                                                                  ((SMG_DELAY * 3) - (NANO_IN_MILLI * 10))) == 0)
+                                                                  (SMG_DELAY - (NANO_IN_MILLI * 10))) == 0)
                                     {
                                         send_message_to_staff(server,
                                                               "Player %s (#%hhu) probably has rapid shooting hack",

--- a/Source/Util/Enums.h
+++ b/Source/Util/Enums.h
@@ -132,7 +132,7 @@ typedef enum {
 
 typedef enum {
     BLOCK_DELAY      = NANO_IN_MILLI * 500,
-    SPADE_DELAY      = NANO_IN_MILLI * 400,
+    SPADE_DELAY      = NANO_IN_MILLI * 200,
     GRENADE_DELAY    = NANO_IN_MILLI * 500,
     THREEBLOCK_DELAY = NANO_IN_MILLI * 1000,
 } tool_delays_t;


### PR DESCRIPTION
SpadesX does not currently keep track of block damage, so we can't really check if block destruction is done too fast at the moment.

Fixes:
- Blocks not being destroyed when hit (detected as rapid shooting) if their HP isn't 100

Changes proposed in this pull request:
- Lowering expected delay for rifle and SMG in BlockAction.c
- Lowering spade delay in Enums.h
