### PR TITLE
Player.c: Reset velocity on respawn

### DIFF
--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -113,6 +113,10 @@ void set_player_respawn_point(server_t* server, player_t* player)
         float dx = spawn->to.x - spawn->from.x;
         float dy = spawn->to.y - spawn->from.y;
 
+        player->movement.velocity.x = 0.f;
+        player->movement.velocity.y = 0.f;
+        player->movement.velocity.z = 0.f;
+
         player->movement.position.x = spawn->from.x + dx * ((float) rand() / (float) RAND_MAX);
         player->movement.position.y = spawn->from.y + dy * ((float) rand() / (float) RAND_MAX);
         player->movement.position.z =


### PR DESCRIPTION
Velocity does not get reset when a player dies mid-air (can happen from /kill or if shot by another player), causing the player to get fall damage when they respawn.

Fixes:
- Velocity not being reset on respawn, causing fall damage if the player was in the air

Changes proposed in this pull request:
- Setting all velocity values to `0` on `set_player_respawn_point` in Player.c