### PR TITLE
Fix ExistingPlayer color and BlockLine

### DIFF
--- a/Source/Server/Packets/BlockAction.c
+++ b/Source/Server/Packets/BlockAction.c
@@ -38,7 +38,7 @@ void send_block_action(server_t* server, player_t* player, uint8_t actionType, i
             node->position.x   = X;
             node->position.y   = Y;
             node->position.z   = Z;
-            node->color        = player->color;
+            node->color        = player->tool_color;
             node->type         = actionType;
             node->sender_id    = player->id;
             LL_APPEND(player->blockBuffer, node);

--- a/Source/Server/Packets/BlockLine.c
+++ b/Source/Server/Packets/BlockLine.c
@@ -29,10 +29,10 @@ void send_block_line(server_t* server, player_t* player, vector3i_t start, vecto
     HASH_ITER(hh, server->players, check, tmp)
     {
         if (is_past_state_data(check)) {
-            if (enet_peer_send(player->peer, 0, packet) == 0) {
+            if (enet_peer_send(check->peer, 0, packet) == 0) {
                 sent = 1;
             }
-        } else if (player->state == STATE_STARTING_MAP || player->state == STATE_LOADING_CHUNKS) {
+        } else if (check->state == STATE_STARTING_MAP || check->state == STATE_LOADING_CHUNKS) {
             block_node_t* node   = (block_node_t*) malloc(sizeof(*node));
             node->position.x     = start.x;
             node->position.y     = start.y;
@@ -40,10 +40,10 @@ void send_block_line(server_t* server, player_t* player, vector3i_t start, vecto
             node->position_end.x = end.x;
             node->position_end.y = end.y;
             node->position_end.z = end.z;
-            node->color          = player->color;
+            node->color          = player->tool_color;
             node->type           = 10;
             node->sender_id      = player->id;
-            LL_APPEND(player->blockBuffer, node);
+            LL_APPEND(check->blockBuffer, node);
         }
     }
     if (sent == 0) {

--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -29,8 +29,9 @@ void send_existing_player(server_t* server, player_t* receiver, player_t* existi
     stream_write_u8(&stream, existing_player->weapon);       // WEAPON
     stream_write_u8(&stream, existing_player->item);         // HELD ITEM
     stream_write_u32(&stream, existing_player->kills);       // KILLS
-    stream_write_color_rgb(&stream, existing_player->color); // COLOR
+    stream_write_color_rgb(&stream, existing_player->tool_color); // COLOR
     stream_write_array(&stream, existing_player->name, 16);  // NAME
+
 
     if (enet_peer_send(receiver->peer, 0, packet) != 0) {
         LOG_WARNING("Failed to send player state");

--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -513,12 +513,12 @@ void for_players(server_t* server)
                 if (node->type == 10) {
                     send_set_color_to_player(server, sender, player, node->color);
                     send_block_line_to_player(server, sender, player, node->position, node->position_end);
-                    send_set_color_to_player(server, sender, player, player->color);
+                    send_set_color_to_player(server, sender, player, player->tool_color);
                 } else {
                     send_set_color_to_player(server, sender, player, node->color);
                     send_block_action_to_player(
                     server, sender, player, node->type, node->position.x, node->position.y, node->position.z);
-                    send_set_color_to_player(server, sender, player, player->color);
+                    send_set_color_to_player(server, sender, player, player->tool_color);
                 }
             not_found:
                 LL_DELETE(player->blockBuffer, node);

--- a/Source/Server/Structs/PlayerStruct.h
+++ b/Source/Server/Structs/PlayerStruct.h
@@ -34,7 +34,6 @@ typedef struct player
     weapon_default_reserve_t default_reserve;
     uint32_t                 kills;
     uint32_t                 deaths;
-    color_t                  color;
     int                      version_minor;
     int                      version_major;
     int                      version_revision;


### PR DESCRIPTION
Fixes:
- BlockLine not being sent to the right players (it was sent to the same player many times, instead of once to each player)
- Joining and seeing players holding a black block instead of the correct color

Changes proposed in this pull request:
- BlockLine: Using the correct variable (`player` is wrong)
- ExistingPlayer: Using the `player->tool_color` variable, and remove `player->color` which was unused