### PR TITLE
Notice.c: Add UTF-8 magic byte for OpenSpades

### DIFF
--- a/Source/Util/Notice.c
+++ b/Source/Util/Notice.c
@@ -18,13 +18,18 @@ void send_server_notice(player_t* player, uint8_t console, const char* message, 
         return;
     }
 
+    uint8_t     utf8         = player->client == 'o';
     uint32_t    fMessageSize = strlen(fMessage);
-    uint32_t    packetSize   = 3 + fMessageSize;
+    uint32_t    packetSize   = 3 + fMessageSize + utf8; // add 1 space for the magic byte
     ENetPacket* packet       = enet_packet_create(NULL, packetSize, ENET_PACKET_FLAG_RELIABLE);
     stream_t    stream       = {packet->data, packet->dataLength, 0};
     stream_write_u8(&stream, PACKET_TYPE_CHAT_MESSAGE);
     stream_write_u8(&stream, player->id);
     stream_write_u8(&stream, 2);
+    if(utf8) {
+        stream_write_u8(&stream, 0xFF);
+    }
+
     stream_write_array(&stream, fMessage, fMessageSize);
     if (enet_peer_send(player->peer, 0, packet) != 0) {
         enet_packet_destroy(packet);
@@ -42,11 +47,21 @@ void broadcast_server_notice(server_t* server, uint8_t console, const char* mess
     uint32_t    fMessageSize = strlen(fMessage);
     uint32_t    packetSize   = 3 + fMessageSize;
     ENetPacket* packet       = enet_packet_create(NULL, packetSize, ENET_PACKET_FLAG_RELIABLE);
+    ENetPacket* packet_utf8  = enet_packet_create(NULL, packetSize + 1, ENET_PACKET_FLAG_RELIABLE);
     stream_t    stream       = {packet->data, packet->dataLength, 0};
+    stream_t    stream_utf8  = {packet_utf8->data, packet_utf8->dataLength, 0};
+
     stream_write_u8(&stream, PACKET_TYPE_CHAT_MESSAGE);
     stream_write_u8(&stream, 33);
     stream_write_u8(&stream, 2);
     stream_write_array(&stream, fMessage, fMessageSize);
+
+    stream_write_u8(&stream_utf8, PACKET_TYPE_CHAT_MESSAGE);
+    stream_write_u8(&stream_utf8, 33);
+    stream_write_u8(&stream_utf8, 2);
+    stream_write_u8(&stream_utf8, 0xFF);
+    stream_write_array(&stream_utf8, fMessage, fMessageSize);
+
     if (console) {
         LOG_INFO("%s", fMessage);
     }
@@ -55,8 +70,14 @@ void broadcast_server_notice(server_t* server, uint8_t console, const char* mess
     HASH_ITER(hh, server->players, player, tmp)
     {
         if (is_past_join_screen(player)) {
-            if (enet_peer_send(player->peer, 0, packet) == 0) {
-                sent = 1;
+            if(player->client == 'o') {
+                if (enet_peer_send(player->peer, 0, packet_utf8) == 0) {
+                    sent = 1;
+                }
+            } else {
+                if (enet_peer_send(player->peer, 0, packet) == 0) {
+                    sent = 1;
+                }
             }
         }
     }

--- a/Source/Util/Notice.c
+++ b/Source/Util/Notice.c
@@ -26,7 +26,7 @@ void send_server_notice(player_t* player, uint8_t console, const char* message, 
     stream_write_u8(&stream, PACKET_TYPE_CHAT_MESSAGE);
     stream_write_u8(&stream, player->id);
     stream_write_u8(&stream, 2);
-    if(utf8) {
+    if (utf8) {
         stream_write_u8(&stream, 0xFF);
     }
 
@@ -66,13 +66,14 @@ void broadcast_server_notice(server_t* server, uint8_t console, const char* mess
         LOG_INFO("%s", fMessage);
     }
     player_t *player, *tmp;
-    uint8_t   sent = 0;
+    uint8_t   sent      = 0;
+    uint8_t   sent_utf8 = 0;
     HASH_ITER(hh, server->players, player, tmp)
     {
         if (is_past_join_screen(player)) {
-            if(player->client == 'o') {
+            if (player->client == 'o') {
                 if (enet_peer_send(player->peer, 0, packet_utf8) == 0) {
-                    sent = 1;
+                    sent_utf8 = 1;
                 }
             } else {
                 if (enet_peer_send(player->peer, 0, packet) == 0) {
@@ -83,5 +84,8 @@ void broadcast_server_notice(server_t* server, uint8_t console, const char* mess
     }
     if (sent == 0) {
         enet_packet_destroy(packet);
+    }
+    if (sent_utf8 == 0) {
+        enet_packet_destroy(packet_utf8);
     }
 }


### PR DESCRIPTION
OpenSpades requires the server to send messages with 0xFF at the beginning in order for them to be treated as UTF-8, otherwise they are treated as CP437. Not sending the byte causes unicode text to show up as garbled.

Fixes:
- Welcome/periodic messages in config showing up as garbled text if unicode characters are used

Changes proposed in this pull request:
- Adding the magic byte OpenSpades expects for UTF-8 support
