### PR TITLE
Add 3D spawn locations

### DIFF
--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -118,6 +118,7 @@ uint8_t get_player_unstuck(server_t* server, player_t* player)
     return 0;
 }
 
+// Find a surface with 3 blocks free and a block under
 static uint8_t is_valid_spawn_point(server_t* server, uint16_t x, uint16_t y, uint16_t z) {
     return   mapvxl_is_solid(&server->s_map.map, x, y, z + 1) &&
             !mapvxl_is_solid(&server->s_map.map, x, y, z)     &&
@@ -146,6 +147,7 @@ void set_player_respawn_point(server_t* server, player_t* player)
         player->movement.forward_orientation.y = 0.f;
         player->movement.forward_orientation.z = 0.f;
 
+        // Find nearest spawn point
         for(uint16_t z = player->movement.position.z; z < server->s_map.map.size_z; z++) {
             if(is_valid_spawn_point(server, player->movement.position.x, player->movement.position.y, z)) {
                 player->movement.position.z = z;
@@ -160,6 +162,7 @@ void set_player_respawn_point(server_t* server, player_t* player)
             }
         }
 
+        // Couldn't find any spawn point, switch player to top of map
         player->movement.position.z = -2.f;
     }
 }

--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -159,6 +159,8 @@ void set_player_respawn_point(server_t* server, player_t* player)
                 return;
             }
         }
+
+        player->movement.position.z = -2.f;
     }
 }
 

--- a/Source/Server/Server.c
+++ b/Source/Server/Server.c
@@ -121,18 +121,18 @@ static void _server_init(server_t*   server,
     struct json_object* parsed_map_json;
     parsed_map_json = json_object_from_file(mapConfig);
 
-    int         team1_start[2];
-    int         team2_start[2];
-    int         team1_end[2];
-    int         team2_end[2];
+    int         team1_start[3];
+    int         team2_start[3];
+    int         team1_end[3];
+    int         team2_end[3];
     int         fog_color[3];
     int         map_size[3];
     const char* author;
 
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team1_start, team1_start, "team1 start", ((int[]){0, 0}), 2, 0)
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team1_end, team1_end, "team1 end", ((int[]){10, 10}), 2, 0)
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team2_start, team2_start, "team2 start", ((int[]){20, 20}), 2, 0)
-    READ_INT_ARR_FROM_JSON(parsed_map_json, team2_end, team2_end, "team2 end", ((int[]){30, 30}), 2, 0)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team1_start, team1_start, "team1 start", ((int[]){0, 0, 0}), 3, 0)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team1_end, team1_end, "team1 end", ((int[]){10, 10, 0}), 3, 0)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team2_start, team2_start, "team2 start", ((int[]){20, 20, 0}), 3, 0)
+    READ_INT_ARR_FROM_JSON(parsed_map_json, team2_end, team2_end, "team2 end", ((int[]){30, 30, 0}), 3, 0)
     READ_INT_ARR_FROM_JSON(parsed_map_json, fog_color, fog_color, "fog color", ((int[]){128, 232, 255}), 3, 0)
     READ_INT_ARR_FROM_JSON(parsed_map_json, map_size, map_size, "map size", ((int[]){512, 512, 64}), 3, 1)
     READ_STR_FROM_JSON(parsed_map_json, author, author, "author", "Unknown", 0)
@@ -172,13 +172,17 @@ static void _server_init(server_t*   server,
 
     server->protocol.spawns[0].from.x = team1_start[0];
     server->protocol.spawns[0].from.y = team1_start[1];
+    server->protocol.spawns[0].from.z = team1_start[2];
     server->protocol.spawns[0].to.x   = team1_end[0];
     server->protocol.spawns[0].to.y   = team1_end[1];
+    server->protocol.spawns[0].to.z   = team1_end[2];
 
     server->protocol.spawns[1].from.x = team2_start[0];
     server->protocol.spawns[1].from.y = team2_start[1];
+    server->protocol.spawns[1].from.z = team2_start[2];
     server->protocol.spawns[1].to.x   = team2_end[0];
     server->protocol.spawns[1].to.y   = team2_end[1];
+    server->protocol.spawns[1].to.z   = team2_end[2];
 
     server->protocol.color_fog.r = fog_color[0];
     server->protocol.color_fog.g = fog_color[1];

--- a/Source/Util/JSONHelpers.h
+++ b/Source/Util/JSONHelpers.h
@@ -22,18 +22,26 @@
 #define READ_STR_FROM_JSON(pj, var, jsonvar, description, fallback, optional) \
     READ_VAR_FROM_JSON(string, "\"%s\"", pj, var, jsonvar, description, fallback, optional)
 
-#define READ_INT_ARR_FROM_JSON(pj, var, jsonvar, description, fallback, fbsize, optional)            \
-    {                                                                                                \
-        struct json_object* _##var;                                                                  \
-        if (!json_object_object_get_ex(pj, #jsonvar, &_##var)) {                                     \
-            if (optional == 0) {                                                                     \
-                LOG_WARNING("Failed to find " description " in config, falling back to " #fallback); \
-            }                                                                                        \
-            for (int i = 0; i < fbsize; ++i)                                                         \
-                var[i] = fallback[i];                                                                \
-        } else                                                                                       \
-            for (int i = 0; i < fbsize; ++i)                                                         \
-                var[i] = json_object_get_int(json_object_array_get_idx(_##var, i));                  \
+#define READ_INT_ARR_FROM_JSON(pj, var, jsonvar, description, fallback, fbsize, optional)                        \
+    {                                                                                                            \
+        struct json_object* _##var;                                                                              \
+        if (!json_object_object_get_ex(pj, #jsonvar, &_##var)) {                                                 \
+            if (optional == 0) {                                                                                 \
+                LOG_WARNING("Failed to find " description " in config, falling back to " #fallback);             \
+            }                                                                                                    \
+            for (int i = 0; i < fbsize; ++i)                                                                     \
+                var[i] = fallback[i];                                                                            \
+        } else {                                                                                                 \
+            int _len_##var = json_object_array_length(_##var);                                                   \
+            for (int i = 0; i < fbsize; ++i) {                                                                   \
+                if (i < _len_##var) {                                                                            \
+                    var[i] = json_object_get_int(json_object_array_get_idx(_##var, i));                          \
+                } else {                                                                                         \
+                    LOG_WARNING("Config option " #jsonvar "[%i] not found, falling back to %i", i, fallback[i]); \
+                    var[i] = fallback[i];                                                                        \
+                }                                                                                                \
+            }                                                                                                    \
+        }                                                                                                        \
     }
 
 #endif


### PR DESCRIPTION
Fixes:
- Being only able to use X and Y in spawn coordinates
- Out-of-bounds read in JSONHelpers

Changes proposed in this pull request:
- Adding Z axis in coordinates and spawnpoint checks
- Using fallback values if int array is smaller than expected