### PR TITLE
Server: Check for invalid floats in all packets

### DIFF
--- a/Source/Server/Packets/OrientationData.c
+++ b/Source/Server/Packets/OrientationData.c
@@ -1,29 +1,35 @@
 #include <Server/Packets/ReceivePackets.h>
 #include <Server/Server.h>
+#include <Util/Checks/VectorChecks.h>
 #include <Util/Physics.h>
 #include <math.h>
 
 void receive_orientation_data(server_t* server, player_t* player, stream_t* data)
 {
     (void) server;
-    float x, y, z;
-    x                 = stream_read_f(data);
-    y                 = stream_read_f(data);
-    z                 = stream_read_f(data);
-    if ((x + y + z) == 0) {
+
+    vector3f_t orientation = {stream_read_f(data), stream_read_f(data), stream_read_f(data)};
+
+    if ((orientation.x + orientation.y + orientation.z) == 0) {
         return;
     }
-    float length      = sqrt((x * x) + (y * y) + (z * z));
-    float norm_legnth = 1 / length;
+
+    if (!valid_vec3f(orientation)) {
+        return;
+    }
+
+    float length      = sqrt((orientation.x * orientation.x) + (orientation.y * orientation.y) + (orientation.z * orientation.z));
+    float norm_length = 1 / length;
+
     // Normalize the vectors if their length > 1
     if (length > 1.f) {
-        player->movement.forward_orientation.x = x * norm_legnth;
-        player->movement.forward_orientation.y = y * norm_legnth;
-        player->movement.forward_orientation.z = z * norm_legnth;
+        player->movement.forward_orientation.x = orientation.x * norm_length;
+        player->movement.forward_orientation.y = orientation.y * norm_length;
+        player->movement.forward_orientation.z = orientation.z * norm_length;
     } else {
-        player->movement.forward_orientation.x = x;
-        player->movement.forward_orientation.y = y;
-        player->movement.forward_orientation.z = z;
+        player->movement.forward_orientation.x = orientation.x;
+        player->movement.forward_orientation.y = orientation.y;
+        player->movement.forward_orientation.z = orientation.z;
     }
 
     physics_reorient_player(player, &player->movement.forward_orientation);

--- a/Source/Server/Packets/PositionData.c
+++ b/Source/Server/Packets/PositionData.c
@@ -1,5 +1,6 @@
 #include <Server/Server.h>
 #include <Util/Checks/PositionChecks.h>
+#include <Util/Checks/VectorChecks.h>
 
 void send_position_packet(server_t* server, player_t* player, float x, float y, float z)
 {
@@ -20,6 +21,10 @@ void send_position_packet(server_t* server, player_t* player, float x, float y, 
 void receive_position_data(server_t* server, player_t* player, stream_t* data)
 {
     vector3f_t position = {stream_read_f(data), stream_read_f(data), stream_read_f(data)};
+
+    if(!valid_vec3f(position)) {
+        return;
+    }
 
     if (distance_in_3d(player->movement.position, position) >= 3) {
         send_position_packet(

--- a/Source/Util/CMakeLists.txt
+++ b/Source/Util/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CHECKS_HEADERS
     Checks/PositionChecks.h
     Checks/TimeChecks.h
     Checks/WeaponChecks.h
+    Checks/VectorChecks.h
 )
 
 set(CHECKS_SOURCES
@@ -20,6 +21,7 @@ set(CHECKS_SOURCES
     Checks/PositionChecks.c
     Checks/TimeChecks.c
     Checks/WeaponChecks.c
+    Checks/VectorChecks.c
 )
 
 set(MT_HEADERS

--- a/Source/Util/Checks/VectorChecks.c
+++ b/Source/Util/Checks/VectorChecks.c
@@ -1,0 +1,9 @@
+#include <Util/Checks/VectorChecks.h>
+#include <Util/Types.h>
+#include <math.h>
+
+inline uint8_t valid_vec3f(vector3f_t vec)
+{
+    return !(isnan(vec.x) || isnan(vec.y) || isnan(vec.z) ||
+             isinf(vec.x) || isinf(vec.y) || isinf(vec.z));
+}

--- a/Source/Util/Checks/VectorChecks.h
+++ b/Source/Util/Checks/VectorChecks.h
@@ -1,0 +1,8 @@
+#ifndef VECTOR_CHECKS_H
+#define VECTOR_CHECKS_H
+
+#include <Util/Types.h>
+
+uint8_t valid_vec3f(vector3f_t vec);
+
+#endif


### PR DESCRIPTION
Fixes:
- Server freezing when grenades with invalid floats as position or velocity are sent
- Player disappearing in VOXLAP/BetterSpades when an orientation with invalid floats is sent

Changes proposed in this pull request:
- Check all packets that have floats for nan/inf and drop them
- Slightly cleanup some related code along the way