### PR TITLE
PositionData.c: Check if player is in solid blocks

### DIFF
--- a/Source/Server/Packets/PositionData.c
+++ b/Source/Server/Packets/PositionData.c
@@ -22,7 +22,7 @@ void receive_position_data(server_t* server, player_t* player, stream_t* data)
 {
     vector3f_t position = {stream_read_f(data), stream_read_f(data), stream_read_f(data)};
 
-    if(!valid_vec3f(position)) {
+    if (!valid_vec3f(position)) {
         return;
     }
 
@@ -30,6 +30,18 @@ void receive_position_data(server_t* server, player_t* player, stream_t* data)
         send_position_packet(
         server, player, player->movement.position.x, player->movement.position.y, player->movement.position.z);
         return;
+    }
+
+    if (player->movement.position.z > 0) {
+        uint16_t x = player->movement.position.x;
+        uint16_t y = player->movement.position.y;
+        uint16_t z = player->movement.position.z;
+
+        if (z <= server->s_map.map.size_z - 2 && mapvxl_is_solid(&server->s_map.map, x, y, z) &&
+            mapvxl_is_solid(&server->s_map.map, x, y, z + 1) && mapvxl_is_solid(&server->s_map.map, x, y, z + 2))
+        {
+            return;
+        }
     }
 
     player->movement.prev_position = player->movement.position;


### PR DESCRIPTION
The position checks we did previously greatly reduce the power of noclip, however, it is still possible to go through blocks at slow speed.
This fix reduces the effectiveness of noclip even further by not allowing movement when the player is fully covered in blocks (3 blocks from feet to head).

Fixes:
- Noclip protection not preventing movement in cases where movement is not possible

Changes proposed in this pull request:
- Drop PositionData packets when the player can't normally move ingame