### PR TITLE
Prevent bad BlockLine placements

### DIFF
--- a/Source/Util/Checks/BlockChecks.c
+++ b/Source/Util/Checks/BlockChecks.c
@@ -14,6 +14,10 @@
 
 uint8_t is_block_placable(server_t* server, vector3i_t pos)
 {
+    if (pos.z >= server->s_map.map.size_z - 2) {
+        return 0;
+    }
+
     static vector3i_t neighbour;
 
     static const vector3i_t offsets[6] = {{0, 0, -1}, {0, -1, 0}, {0, 1, 0}, {-1, 0, 0}, {1, 0, 0}, {0, 0, 1}};


### PR DESCRIPTION
Fixes:
- Being able to place block lines midair and on water
- Being able to place regular blocks on water

Changes proposed in this pull request:
- Add a Z check to `is_block_placable` to prevent placing blocks on/under water
- Add the same `is_block_placable` checks as BlockAction to BlockLine