### PR TITLE
All: Check for memory allocation failures everywhere

### DIFF
--- a/Source/Main.c
+++ b/Source/Main.c
@@ -6,6 +6,7 @@
 #include <Util/Log.h>
 #include <Util/Types.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 #include <json-c/json.h>
 #include <json-c/json_object.h>
 #include <stdio.h>
@@ -72,12 +73,8 @@ int main(void)
     for (int i = 0; i < map_list_len; ++i) {
         json_object*   temp       = json_object_array_get_idx(map_in_config, i);
         uint8_t        string_len = json_object_get_string_len(temp);
-        string_node_t* map_name   = malloc(sizeof(string_node_t));
-        char*          map        = malloc(sizeof(char) * string_len + 1);
-        if (map_name == NULL || map == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            exit(EXIT_FAILURE);
-        }
+        string_node_t* map_name   = spadesx_malloc(sizeof(string_node_t));
+        char*          map        = spadesx_malloc(sizeof(char) * string_len + 1);
         memcpy(map, json_object_get_string(temp), string_len + 1);
         map_name->string = map;
         DL_APPEND(map_list, map_name);
@@ -94,12 +91,8 @@ int main(void)
             "Welcome message in config with index %d exceeds 128 characters. Please use shorter message. IGNORING", i);
             continue;
         }
-        string_node_t* welcome_message        = malloc(sizeof(string_node_t));
-        char*          welcome_message_string = malloc(sizeof(char) * stringLen + 1);
-        if (welcome_message == NULL || welcome_message_string == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            exit(EXIT_FAILURE);
-        }
+        string_node_t* welcome_message        = spadesx_malloc(sizeof(string_node_t));
+        char*          welcome_message_string = spadesx_malloc(sizeof(char) * stringLen + 1);
         memcpy(welcome_message_string, json_object_get_string(temp), stringLen + 1);
         welcome_message->string = welcome_message_string;
         DL_APPEND(welcome_message_list, welcome_message);
@@ -116,12 +109,8 @@ int main(void)
             "Periodic message in config with index %d exceeds 128 characters. Please use shorter message. IGNORING", i);
             continue;
         }
-        string_node_t* periodic_message        = malloc(sizeof(string_node_t));
-        char*          periodic_message_string = malloc(sizeof(char) * string_len + 1);
-        if (periodic_message == NULL || periodic_message_string == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            exit(EXIT_FAILURE);
-        }
+        string_node_t* periodic_message        = spadesx_malloc(sizeof(string_node_t));
+        char*          periodic_message_string = spadesx_malloc(sizeof(char) * string_len + 1);
         memcpy(periodic_message_string, json_object_get_string(temp), string_len + 1);
         periodic_message->string = periodic_message_string;
         DL_APPEND(periodic_message_list, periodic_message);

--- a/Source/Server/Commands/CommandManager.c
+++ b/Source/Server/Commands/CommandManager.c
@@ -12,6 +12,7 @@
 #include <Util/Types.h>
 #include <Util/Uthash.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 #include <ctype.h>
 #include <enet/enet.h>
 #include <json-c/json.h>
@@ -81,12 +82,7 @@ void command_create(server_t* server,
                     char     description[1024],
                     uint32_t permissions)
 {
-    command_t* cmd   = malloc(sizeof(command_t));
-    if (cmd == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            server->running = 0;
-            return;
-        }
+    command_t* cmd   = spadesx_malloc(sizeof(command_t));
     cmd->execute     = command;
     cmd->parse_args  = parse_args;
     cmd->permissions = permissions;
@@ -229,12 +225,8 @@ static uint8_t parse_arguments(command_args_t* arguments, char* message, uint8_t
             argument_length--; // don't need that last quote mark
         }
         if (argument_length) {
-            char* argument            = malloc(argument_length + 1);
-            if (argument == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            arguments->server->running = 0;
-            return 0;
-        } // Don't forget about the null terminator!
+            char* argument            = spadesx_malloc(argument_length + 1);
+            // Don't forget about the null terminator!
             argument[argument_length] = '\0';
             memcpy(argument, p, argument_length);
             arguments->argv[arguments->argc++] = argument;
@@ -251,7 +243,7 @@ void command_handle(server_t* server, player_t* player, char* message, uint8_t c
         send_server_notice(player, console, "This command is longer then the 1000 character limit. Thus it has been ignored");
         return;
     }
-    char* command = calloc(1000, sizeof(char));
+    char* command = spadesx_calloc(1000, sizeof(char));
     sscanf(message, "%s", command);
     uint8_t command_length = strlen(command);
     for (uint8_t i = 1; i < command_length; ++i) {
@@ -280,7 +272,7 @@ void command_handle(server_t* server, player_t* player, char* message, uint8_t c
         }
     } else if ((message_length = strlen(message)) - command_length > 1)
     { // if we have something other than the command itself
-        char* argument = calloc(message_length - command_length, sizeof(message[0]));
+        char* argument = spadesx_calloc(message_length - command_length, sizeof(message[0]));
         strcpy(argument, message + command_length + 1);
         arguments.argv[arguments.argc++] = argument;
     }

--- a/Source/Server/Events.h
+++ b/Source/Server/Events.h
@@ -1,10 +1,11 @@
-// Copyright SpadesX team 2022
+// Copyright SpadesX team 2023
 #ifndef EVENTS_H
 #define EVENTS_H
 
 #include <Server/Structs/PlayerStruct.h>
 #include <Util/Log.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -63,11 +64,7 @@ enum { EVENT_FIRST, EVENT_LAST };
     void event##_subscribe(event##Callback callback, int position)      \
     {                                                                   \
         struct event##Listener* el;                                     \
-        el = malloc(sizeof *el);                                        \
-        if (!el) {                                                      \
-            LOG_ERROR("Out of memory. Oh well.");                       \
-            return;                                                     \
-        }                                                               \
+        el           = spadesx_malloc(sizeof *el);                      \
         el->callback = callback;                                        \
         if (position == EVENT_LAST)                                     \
             LL_APPEND(g_##event##Listeners, el);                        \

--- a/Source/Server/Map.c
+++ b/Source/Server/Map.c
@@ -6,6 +6,7 @@
 #include <Util/Queue.h>
 #include <Util/Types.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 #include <errno.h>
 #include <libmapvxl/libmapvxl.h>
 #include <stdio.h>
@@ -47,7 +48,7 @@ uint8_t map_load(server_t* server, const char* path, int map_size[3])
         return 0;
     }
 
-    uint8_t* buffer = (uint8_t*) calloc(server->s_map.map_size, sizeof(uint8_t));
+    uint8_t* buffer = (uint8_t*) spadesx_calloc(server->s_map.map_size, sizeof(uint8_t));
 
     if (fread(buffer, server->s_map.map_size, 1, file) < server->s_map.map_size) {
         LOG_STATUS("Finished loading map");

--- a/Source/Server/Nodes.c
+++ b/Source/Server/Nodes.c
@@ -1,6 +1,7 @@
 #include <Server/Structs/ServerStruct.h>
 #include <Util/Checks/PositionChecks.h>
 #include <Util/Log.h>
+#include <Util/Alloc.h>
 
 vector3i_t* get_neighbours(vector3i_t pos)
 {
@@ -54,12 +55,7 @@ uint8_t check_node(server_t* server, vector3i_t position)
         return 1;
     }
     if (nodes == NULL) {
-        nodes = (vector3i_t*) malloc(sizeof(vector3i_t) * NODE_RESERVE_SIZE);
-        if (nodes == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            server->running = 0;
-            return 0;
-        }
+        nodes = (vector3i_t*) spadesx_malloc(sizeof(vector3i_t) * NODE_RESERVE_SIZE);
         nodesSize = NODE_RESERVE_SIZE;
     }
     nodePos    = 0;
@@ -103,12 +99,7 @@ uint8_t check_node(server_t* server, vector3i_t position)
                  position.y * server->s_map.map.size_z + position.z;
         HASH_FIND_INT(visitedMap, &id, node);
         if (node == NULL) {
-            node          = (map_node_t*) malloc(sizeof *node);
-            if (node == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            server->running = 0;
-            return 0;
-        }
+            node          = (map_node_t*) spadesx_malloc(sizeof *node);
             node->pos     = position;
             node->visited = 1;
             node->id      = id;

--- a/Source/Server/Packets/BlockAction.c
+++ b/Source/Server/Packets/BlockAction.c
@@ -14,6 +14,7 @@
 #include <Util/Nanos.h>
 #include <Util/Uthash.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 #include <stdint.h>
 
 void send_block_action(server_t* server, player_t* player, uint8_t actionType, int X, int Y, int Z)
@@ -38,12 +39,7 @@ void send_block_action(server_t* server, player_t* player, uint8_t actionType, i
                 sent = 1;
             }
         } else if (player->state == STATE_STARTING_MAP || player->state == STATE_LOADING_CHUNKS) {
-            block_node_t* node = (block_node_t*) malloc(sizeof(*node));
-            if (node == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            server->running = 0;
-            return;
-        }
+            block_node_t* node = (block_node_t*) spadesx_malloc(sizeof(*node));
             node->position.x   = X;
             node->position.y   = Y;
             node->position.z   = Z;

--- a/Source/Server/Packets/BlockLine.c
+++ b/Source/Server/Packets/BlockLine.c
@@ -9,6 +9,7 @@
 #include <Util/Nanos.h>
 #include <Util/Uthash.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 
 void send_block_line(server_t* server, player_t* player, vector3i_t start, vector3i_t end)
 {
@@ -34,12 +35,7 @@ void send_block_line(server_t* server, player_t* player, vector3i_t start, vecto
                 sent = 1;
             }
         } else if (check->state == STATE_STARTING_MAP || check->state == STATE_LOADING_CHUNKS) {
-            block_node_t* node   = (block_node_t*) malloc(sizeof(*node));
-            if (node == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            server->running = 0;
-            return;
-        }
+            block_node_t* node   = (block_node_t*) spadesx_malloc(sizeof(*node));
             node->position.x     = start.x;
             node->position.y     = start.y;
             node->position.z     = start.z;

--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -8,6 +8,7 @@
 #include <Util/Uthash.h>
 #include <Util/Utlist.h>
 #include <Util/Weapon.h>
+#include <Util/Alloc.h>
 #include <ctype.h>
 
 #ifdef _WIN32
@@ -83,12 +84,7 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
         invName = 1;
     }
 
-    char* lowerCaseName = malloc((strlen(player->name) + 1) * sizeof(char));
-    if (lowerCaseName == NULL) {
-        LOG_ERROR("Allocation of memory failed. EXITING");
-        server->running = 0;
-        return;
-    }
+    char* lowerCaseName = spadesx_malloc((strlen(player->name) + 1) * sizeof(char));
     snprintf(lowerCaseName, strlen(player->name), "%s", player->name);
 
     for (uint32_t i = 0; i < strlen(player->name); ++i)

--- a/Source/Server/Packets/Grenade.c
+++ b/Source/Server/Packets/Grenade.c
@@ -10,6 +10,7 @@
 #include <Util/Nanos.h>
 #include <Util/Notice.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 #include <math.h>
 
 void send_grenade(server_t* server, player_t* player, float fuse, vector3f_t position, vector3f_t velocity)
@@ -58,12 +59,7 @@ void receive_grenade_packet(server_t* server, player_t* player, stream_t* data)
     }
 
     if (player->grenades > 0) {
-        grenade_t* grenade  = malloc(sizeof(grenade_t));
-        if (grenade == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            server->running = 0;
-            return;
-        }
+        grenade_t* grenade  = spadesx_malloc(sizeof(grenade_t));
 
         float fuse = stream_read_f(data);
         if (isnan(fuse) || isinf(fuse)) {

--- a/Source/Server/Packets/MapStart.c
+++ b/Source/Server/Packets/MapStart.c
@@ -1,6 +1,7 @@
 #include <Util/Utlist.h>
 #include <Server/Server.h>
 #include <Util/Compress.h>
+#include <Util/Alloc.h>
 #include <Util/Log.h>
 
 void send_map_start(server_t* server, player_t* player)
@@ -10,7 +11,7 @@ void send_map_start(server_t* server, player_t* player)
     }
 
     // The biggest possible VXL size given the XYZ size
-    uint8_t* map = (uint8_t*) calloc(
+    uint8_t* map = (uint8_t*) spadesx_calloc(
     server->s_map.map.size_x * server->s_map.map.size_y * (server->s_map.map.size_z / 2), sizeof(uint8_t));
     // Write map to out
     server->s_map.map_size = mapvxl_write(&server->s_map.map, map);

--- a/Source/Server/Packets/Message.c
+++ b/Source/Server/Packets/Message.c
@@ -7,6 +7,7 @@
 #include <Util/Nanos.h>
 #include <Util/Notice.h>
 #include <Util/Uthash.h>
+#include <Util/Alloc.h>
 #include <ctype.h>
 #include <string.h>
 
@@ -22,8 +23,8 @@ void receive_handle_send_message(server_t* server, player_t* player, stream_t* d
     if (length > 2048) {
         length = 2048; // Lets limit messages to 2048 characters
     }
-    char* message =
-    calloc(length + 1, sizeof(char)); // Allocated 1 more byte in the case that client sent us non null ending string
+    char* message = spadesx_calloc(
+    length + 1, sizeof(char)); // Allocated 1 more byte in the case that client sent us non null ending string
     stream_read_array(data, message, length);
     if (message[length - 1] != '\0') {
         message[length] = '\0';

--- a/Source/Server/Packets/PacketManager.c
+++ b/Source/Server/Packets/PacketManager.c
@@ -7,6 +7,7 @@
 #include <Util/Physics.h>
 #include <Util/Uthash.h>
 #include <Util/Utlist.h>
+#include <Util/Alloc.h>
 
 inline uint8_t allow_shot(server_t*  server,
                           player_t*  player,
@@ -83,12 +84,7 @@ void init_packets(server_t* server)
                                   {30, &receive_change_weapon},
                                   {34, &receive_version_response}};
     for (unsigned long i = 0; i < sizeof(packets) / sizeof(packet_manager_t); i++) {
-        packet_t* packet = malloc(sizeof(packet_t));
-        if (packet == NULL) {
-            LOG_ERROR("Allocation of memory failed. EXITING");
-            server->running = 0;
-            return;
-        }
+        packet_t* packet = spadesx_malloc(sizeof(packet_t));
         packet->id       = packets[i].id;
         packet->packet   = packets[i].packet;
         HASH_ADD_INT(server->packets, id, packet);

--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -18,6 +18,7 @@
 #include <Util/Uthash.h>
 #include <Util/Utlist.h>
 #include <Util/Weapon.h>
+#include <Util/Alloc.h>
 #include <enet/enet.h>
 #include <json-c/json_util.h>
 #include <math.h>
@@ -435,7 +436,7 @@ void on_new_player_connection(server_t* server, ENetEvent* event)
         LOG_WARNING("Server full. Kicking player");
         return;
     }
-    player_t*  player  = calloc(1, sizeof(player_t));
+    player_t*  player  = spadesx_calloc(1, sizeof(player_t));
     vector3f_t empty   = {0, 0, 0};
     vector3f_t forward = {1, 0, 0};
     vector3f_t height  = {0, 0, 1};

--- a/Source/Util/Alloc.c
+++ b/Source/Util/Alloc.c
@@ -1,0 +1,25 @@
+#include <Util/Alloc.h>
+#include <Util/Log.h>
+#include <stdlib.h>
+
+inline void* spadesx_malloc(size_t size)
+{
+    void* ptr = malloc(size);
+    if (ptr == NULL) {
+        LOG_ERROR("malloc() failed to allocate %zu bytes of memory", size);
+        abort();
+    }
+
+    return ptr;
+}
+
+inline void* spadesx_calloc(size_t num, size_t size)
+{
+    void* ptr = calloc(num, size);
+    if (ptr == NULL) {
+        LOG_ERROR("calloc() failed to allocate %zu bytes of memory", num * size);
+        abort();
+    }
+
+    return ptr;
+}

--- a/Source/Util/Alloc.h
+++ b/Source/Util/Alloc.h
@@ -1,0 +1,9 @@
+#ifndef ALLOC_H
+#define ALLOC_H
+
+#include <stddef.h>
+
+void* spadesx_malloc(size_t size);
+void* spadesx_calloc(size_t num, size_t size);
+
+#endif

--- a/Source/Util/CMakeLists.txt
+++ b/Source/Util/CMakeLists.txt
@@ -45,6 +45,7 @@ set(UTIL_HEADERS
     Nanos.h
     Notice.h
     Weapon.h
+    Alloc.h
 )
 
 set(UTIL_SOURCES
@@ -58,6 +59,7 @@ set(UTIL_SOURCES
     Nanos.c
     Notice.c
     Weapon.c
+    Alloc.c
 )
 
 target_sources(Util

--- a/Source/Util/DataStream.c
+++ b/Source/Util/DataStream.c
@@ -2,17 +2,13 @@
 #include <Server/Structs/PacketStruct.h>
 #include <Util/DataStream.h>
 #include <Util/Log.h>
+#include <Util/Alloc.h>
 #include <stdlib.h>
 #include <string.h>
 
-
 void stream_create(stream_t* stream, uint32_t length)
 {
-    stream->data = malloc(length);
-    if (stream->data == NULL) {
-        LOG_ERROR("Allocation of memory failed. EXITING");
-        return;
-    }
+    stream->data = spadesx_malloc(length);
     stream->length = length;
     stream->pos    = 0;
 }


### PR DESCRIPTION
Fixes:
- Repeated allocation checks in some places
- Some missing checks (mostly `calloc`s)

Changes proposed in this pull request:
- Create wrapper functions `spadesx_malloc` and `spadesx_calloc` for malloc/calloc respectively
- Replace all uses of malloc/calloc with our own wrappers