### PR TITLE
ExistingPlayer.c: Use correct dstsize for strlcat.

### DIFF
--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -126,7 +126,7 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
     if (count > 0) {
         char idChar[4];
         snprintf(idChar, 4, "%d", player->id);
-        strlcat(player->name, idChar, 17);
+        strlcat(player->name, idChar, 16);
     }
 
     set_default_player_ammo(player);


### PR DESCRIPTION
Fixes:
- Compilation on GCC 13.1.1 20230429.
- Half of #72.

Changes proposed in this pull request:
- Changing the dstsize of a strlcat for distinguishing player names from 17 octets, which is far too large for a player name, to 16 octets (INCLUDING the NULL terminator).
