### PR TITLE
(mostly) fix spectator and fix players spawning inside blocks

### DIFF
--- a/Source/Server/IntelTent.c
+++ b/Source/Server/IntelTent.c
@@ -202,10 +202,10 @@ vector3f_t set_intel_tent_spawn_point(server_t* server, uint8_t team)
 void handleTentAndIntel(server_t* server, player_t* player)
 {
     uint8_t team;
-    if (player->team == 0) {
-        team = 1;
+    if (player->team == TEAM_A) {
+        team = TEAM_B;
     } else {
-        team = 0;
+        team = TEAM_A;
     }
     if (player->team != TEAM_SPECTATOR) {
         uint64_t timeNow = time(NULL);

--- a/Source/Server/Packets/ChangeTeam.c
+++ b/Source/Server/Packets/ChangeTeam.c
@@ -4,24 +4,34 @@
 
 void receive_change_team(server_t* server, player_t* player, stream_t* data)
 {
+    // @Todo: if player is not initialised yet (pyspades uses if not self.name) ignore this
+
     uint8_t received_id = stream_read_u8(data);
-    server->protocol.num_team_users[player->team]--;
-    uint8_t team = stream_read_u8(data);
 
-    if (team == 255) {
-        team = 2;
-    }
+    uint8_t team     = stream_read_u8(data);
+    uint8_t old_team = player->team;
 
-    if (team != 0 && team != 1 && team != 2) {
+    if (old_team == team)
+        return;
+
+    if (team != TEAM_A && team != TEAM_B && team != TEAM_SPECTATOR) {
         LOG_WARNING("Player %s (#%hhu) sent invalid team. Switching them to Spectator", player->name, player->id);
-        team = 2;
+        team = TEAM_SPECTATOR;
     }
 
-    player->team = team;
     if (player->id != received_id) {
         LOG_WARNING("Assigned ID: %d doesnt match sent ID: %d in change team packet", player->id, received_id);
     }
-    server->protocol.num_team_users[player->team]++;
-    send_kill_action_packet(server, player, player, 5, 5, 0);
-    player->state = STATE_WAITING_FOR_RESPAWN;
+
+    if (server->protocol.num_team_users[old_team] > 0)
+        server->protocol.num_team_users[old_team]--;
+
+    player->team = team;
+    server->protocol.num_team_users[team]++;
+
+    if (old_team == TEAM_SPECTATOR) {
+        send_respawn(server, player);
+    } else {
+        send_kill_action_packet(server, player, player, 5, 5, 0);
+    }
 }

--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -1,6 +1,7 @@
 #include <Server/Packets/Packets.h>
 #include <Server/ParseConvert.h>
 #include <Server/Server.h>
+#include <Util/Alloc.h>
 #include <Util/Checks/PlayerChecks.h>
 #include <Util/Enums.h>
 #include <Util/Log.h>
@@ -8,7 +9,6 @@
 #include <Util/Uthash.h>
 #include <Util/Utlist.h>
 #include <Util/Weapon.h>
-#include <Util/Alloc.h>
 #include <ctype.h>
 
 #ifdef _WIN32
@@ -41,7 +41,7 @@ void send_existing_player(server_t* server, player_t* receiver, player_t* existi
 
 void receive_existing_player(server_t* server, player_t* player, stream_t* data)
 {
-    if (player->team != 2) {
+    if (player->team != TEAM_SPECTATOR) {
         return;
     }
     stream_skip(data, 1); // Clients always send a "dumb" ID here since server has not sent them their ID yet
@@ -50,16 +50,12 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
     player->item   = stream_read_u8(data);
     player->kills  = stream_read_u32(data);
 
-    if (player->team == 255) {
-        player->team = 2;
-    }
-
-    if (player->team != 0 && player->team != 1 && player->team != 2) {
+    if (player->team != TEAM_A && player->team != TEAM_B && player->team != TEAM_SPECTATOR) {
         LOG_WARNING("Player %s (#%hhu) sent invalid team. Switching them to Spectator", player->name, player->id);
-        player->team = 2;
+        player->team = TEAM_SPECTATOR;
     }
 
-    if (player->team != 2) {
+    if (player->team != TEAM_SPECTATOR) {
         server->protocol.num_team_users[player->team]++;
     }
 

--- a/Source/Server/Packets/IntelCapture.c
+++ b/Source/Server/Packets/IntelCapture.c
@@ -8,10 +8,10 @@ void send_intel_capture(server_t* server, player_t* player, uint8_t winning)
         return;
     }
     uint8_t team;
-    if (player->team == 0) {
-        team = 1;
+    if (player->team == TEAM_A) {
+        team = TEAM_B;
     } else {
-        team = 0;
+        team = TEAM_A;
     }
     if (player->has_intel == 0 || server->protocol.gamemode.intel_held[team] == 0) {
         return;

--- a/Source/Server/Packets/IntelDrop.c
+++ b/Source/Server/Packets/IntelDrop.c
@@ -10,10 +10,10 @@ void send_intel_drop(server_t* server, player_t* player)
         return;
     }
     uint8_t team;
-    if (player->team == 0) {
-        team = 1;
+    if (player->team == TEAM_A) {
+        team = TEAM_B;
     } else {
-        team = 0;
+        team = TEAM_A;
     }
     if (player->has_intel == 0 || server->protocol.gamemode.intel_held[team] == 0) {
         return;

--- a/Source/Server/Packets/IntelPickup.c
+++ b/Source/Server/Packets/IntelPickup.c
@@ -7,10 +7,10 @@ void send_intel_pickup(server_t* server, player_t* player)
         return;
     }
     uint8_t team;
-    if (player->team == 0) {
-        team = 1;
+    if (player->team == TEAM_A) {
+        team = TEAM_B;
     } else {
-        team = 0;
+        team = TEAM_A;
     }
     if (player->has_intel == 1 || server->protocol.gamemode.intel_held[team] == 1) {
         return;

--- a/Source/Server/Packets/KillAction.c
+++ b/Source/Server/Packets/KillAction.c
@@ -17,6 +17,11 @@ void send_kill_action_packet(server_t* server,
     if (player->alive == 0) {
         return; // Cant kill player if they are dead
     }
+
+    if (player->has_intel) {
+        send_intel_drop(server, player);
+    }
+
     ENetPacket* packet = enet_packet_create(NULL, 5, ENET_PACKET_FLAG_RELIABLE);
     stream_t    stream = {packet->data, packet->dataLength, 0};
     stream_write_u8(&stream, PACKET_TYPE_KILL_ACTION);
@@ -68,8 +73,5 @@ void send_kill_action_packet(server_t* server,
                 player->default_reserve = SHOTGUN_DEFAULT_RESERVE;
                 break;
         }
-    }
-    if (player->has_intel) {
-        send_intel_drop(server, player);
     }
 }

--- a/Source/Server/Packets/Message.c
+++ b/Source/Server/Packets/Message.c
@@ -1,13 +1,13 @@
 #include <Server/Commands/Commands.h>
 #include <Server/Server.h>
 #include <Server/Staff.h>
+#include <Util/Alloc.h>
 #include <Util/Checks/PlayerChecks.h>
 #include <Util/Checks/TimeChecks.h>
 #include <Util/Log.h>
 #include <Util/Nanos.h>
 #include <Util/Notice.h>
 #include <Util/Uthash.h>
-#include <Util/Alloc.h>
 #include <ctype.h>
 #include <string.h>
 
@@ -104,7 +104,7 @@ void receive_handle_send_message(server_t* server, player_t* player, stream_t* d
             HASH_ITER(hh, server->players, connected_player, tmp)
             {
                 if (is_past_join_screen(connected_player) && !player->muted &&
-                    ((connected_player->team == player->team && meant_for == 1) || meant_for == 0))
+                    ((connected_player->team == player->team && meant_for == TEAM_B) || meant_for == TEAM_A))
                 {
                     if (enet_peer_send(connected_player->peer, 0, packet) == 0) {
                         sent = 1;

--- a/Source/Server/Packets/ShortPlayerData.c
+++ b/Source/Server/Packets/ShortPlayerData.c
@@ -11,16 +11,16 @@
 
 void receive_short_player(server_t* server, player_t* player, stream_t* data)
 {
-    if (player->team != 2) {
+    if (player->team != TEAM_SPECTATOR) {
         return;
     }
     stream_skip(data, 1); // Sender has to match the player we are getting info of.
     player->team   = stream_read_u8(data);
     player->weapon = stream_read_u8(data);
 
-    if (player->team != 0 && player->team != 1 && player->team != 2) {
+    if (player->team != TEAM_A && player->team != TEAM_B && player->team != TEAM_SPECTATOR) {
         LOG_WARNING("Player %s (#%hhu) sent invalid team. Switching them to Spectator", player->name, player->id);
-        player->team = 2;
+        player->team = TEAM_SPECTATOR;
     }
 
     set_default_player_ammo(player);

--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -151,20 +151,20 @@ void set_player_respawn_point(server_t* server, player_t* player)
         // Find nearest spawn point
         for (uint16_t z = player->movement.position.z; z < server->s_map.map.size_z; z++) {
             if (is_valid_spawn_point(server, player->movement.position.x, player->movement.position.y, z)) {
-                player->movement.position.z = z;
+                player->movement.position.z = z - 2.4F;
                 return;
             }
         }
 
         for (uint16_t z = player->movement.position.z; z > 0; z--) {
             if (is_valid_spawn_point(server, player->movement.position.x, player->movement.position.y, z)) {
-                player->movement.position.z = z;
+                player->movement.position.z = z - 2.4F;
                 return;
             }
         }
 
         // Couldn't find any spawn point, switch player to top of map
-        player->movement.position.z = -2.f;
+        player->movement.position.z = -2.4f;
     }
 }
 

--- a/Source/Util/Enums.h
+++ b/Source/Util/Enums.h
@@ -81,7 +81,7 @@ typedef enum {
 typedef enum {
     TEAM_A         = 0,
     TEAM_B         = 1,
-    TEAM_SPECTATOR = 2,
+    TEAM_SPECTATOR = 255,
 } team_t;
 
 typedef enum {
@@ -144,9 +144,9 @@ typedef enum {
 } gun_delays_t;
 
 typedef enum {
-    BLOCKACTION_BUILD = 0,
-    BLOCKACTION_DESTROY_ONE = 1,
-    BLOCKACTION_DESTROY_THREE = 2,
+    BLOCKACTION_BUILD           = 0,
+    BLOCKACTION_DESTROY_ONE     = 1,
+    BLOCKACTION_DESTROY_THREE   = 2,
     BLOCKACTION_DESTROY_GRENADE = 3,
 } block_action_types_t;
 


### PR DESCRIPTION
You might want to skim through the code first. Also I had some formatter installed and it changed some other formatting, but it's fine I hope. I couldn't find any way to break spectator mode now but I don't know all the edge cases in my head. 

Tested in BeS, OS

Fixes:
- spectator mode completely broken
- you can now view players POV too
Changes proposed in this pull request:
- z spawn offset used same as in pyspades, resulting in the familiar "drop on spawn"