### PR TITLE
.gitignore: Exclude .idea and cmake-build-debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 .vscode
 workspace.code-workspace
 compile_commands.json
+.idea
+cmake-build-debug


### PR DESCRIPTION
I don't like doing tiny PRs like this.. but I sometimes use CMine and I'd rather not accidentally commit IDE workspace files in

Fixes:
- `.idea` and `cmake-build-debug` directories not being ignored by `gitignore`

Changes proposed in this pull request:
- N/A
