### PR TITLE
CMakeLists.txt: Make the Git submodule fetch optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_INTERPROCEDURAL_OPTIMIZATION ON)
 option(CMAKE_UNITY_BUILD "Enable Unity Build" ON)
 
+option(GIT_SUBMODULES_FETCH "Fetch the required Git submodules" ON)
+
 # Add third party libraries
 add_subdirectory(Extern)
 

--- a/Extern/CMakeLists.txt
+++ b/Extern/CMakeLists.txt
@@ -1,9 +1,11 @@
-find_package(Git REQUIRED)
+if (GIT_SUBMODULES_FETCH)
+  find_package(Git REQUIRED)
 
-if(NOT EXISTS libmapvxl/CMakeLists.txt OR NOT EXISTS spadesx_enet/CMakeLists.txt)
-  execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${dir}
-    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-    COMMAND_ERROR_IS_FATAL ANY)
+  if(NOT EXISTS libmapvxl/CMakeLists.txt OR NOT EXISTS spadesx_enet/CMakeLists.txt)
+    execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive -- ${dir}
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      COMMAND_ERROR_IS_FATAL ANY)
+  endif()
 endif()
 
 add_subdirectory(libmapvxl)


### PR DESCRIPTION
Use case: without this parameter, the Docker container would attempt to fetch the submodules, which requires installing Git, thus making the build process longer. It's better to run the `git submodules update` command on the build machine and then run the Dockerfile.