### PR TITLE
Revise signal handling code

### DIFF
--- a/Source/Server/Console.c
+++ b/Source/Server/Console.c
@@ -15,10 +15,8 @@
 
 volatile int ctrlc = 0;
 
-void readline_new_line(int signal)
+void handle_sigint()
 {
-    (void) signal; // To prevent a warning about unused variable
-
     ctrlc = 1;
     printf("\n");
     LOG_INFO_WITHOUT_TIME("Are you sure you want to exit? (Y/n)\n");

--- a/Source/Server/Console.h
+++ b/Source/Server/Console.h
@@ -2,6 +2,6 @@
 #define CONSOLE_H
 
 void* server_console(void* arg);
-void  readline_new_line(int signal);
+void  handle_sigint(); // Old signature: readline_new_line(int signal)
 
 #endif

--- a/Source/Server/Server.c
+++ b/Source/Server/Server.c
@@ -349,7 +349,7 @@ static void _handle_signal(const int sig)
             stop_server();
             break;
         default:
-            LOG_ERROR("Received unhandled signal %d", signal);
+            LOG_ERROR("Received unhandled signal %d", sig);
             break;
     }
 }

--- a/Source/Server/Server.c
+++ b/Source/Server/Server.c
@@ -317,6 +317,54 @@ void stop_server(void)
     server.running = 0;
 }
 
+static void _set_sigaction(const int sig, const struct sigaction *sigact, const char *sig_name)
+{
+    /*
+    GCC recommends to not replace existing sigaction structs
+    if they specify SIG_IGN
+    */
+    struct sigaction prev_act;
+    sigaction(sig, NULL, &prev_act);
+    if(prev_act.sa_handler == SIG_IGN)
+    {
+        // signal should be ignored - so let's not tamper with it
+        return;
+    } 
+
+    // sigaction returns 0 if success, -1 if error
+    if(sigaction(sig, sigact, NULL))
+    {
+        LOG_ERROR("Unable to set sigaction for %s", sig_name);
+    }
+}
+
+static void _handle_signal(const int sig)
+{
+    switch(sig)
+    {
+        case SIGINT:
+            readline_new_line(sig);
+            break;
+        case SIGTERM:
+            stop_server();
+            break;
+        default:
+            LOG_ERROR("Received unhandled signal %d", signal);
+            break;
+    }
+}
+
+static inline void _apply_signal_handlers()
+{
+    struct sigaction sigact;
+    sigact.sa_handler = _handle_signal;
+    sigemptyset(&sigact.sa_mask);
+    sigact.sa_flags = 0;
+
+    _set_sigaction(SIGINT, &sigact, "SIGINT");
+    _set_sigaction(SIGTERM, &sigact, "SIGTERM");
+}
+
 void server_start(server_args args)
 {
     server.global_timers.time_since_start = get_nanos();
@@ -401,8 +449,7 @@ void server_start(server_args args)
     pthread_t console;
     pthread_create(&console, NULL, server_console, (void*) &server);
     pthread_detach(console);
-
-    signal(SIGINT, readline_new_line);
+    _apply_signal_handlers();
 
     while (server.running) {
         pthread_mutex_lock(&server_lock);

--- a/Source/Server/Server.c
+++ b/Source/Server/Server.c
@@ -343,7 +343,7 @@ static void _handle_signal(const int sig)
     switch(sig)
     {
         case SIGINT:
-            readline_new_line(sig);
+            handle_sigint();
             break;
         case SIGTERM:
             stop_server();


### PR DESCRIPTION
Resolves #82 

There are three motives behind this
- Handle `SIGTERM` for #82 which is important for running spadesx in docker.
- Have the code be ready for additional signals to be handled if required in the future.
- Rename `readline_new_line` so its purpose makes more sense to the reader.

This PR contains two commits (as of publishing):
- 17b5cf63669b6a6830c1157d74d5c5fb86146c7d is the primary commit which adds a few functions (intended for future expandability if need be) but the main difference is that it handles `SIGTERM` by running `server_stop()`.
- f20b333c1d1ea3c16b38c5f5e188c231c8526d6f aims to make the code more readable by changing the function name and signature of `readline_new_line(int)` in `Console.h` to `handle_sigint()`.

Please let me know if there is anything you want changed, also feel free to commit directly to the branch (Allow edits by maintainers is enabled).