### PR TITLE
gitignore: add macOS files to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ cmake-build-debug/
 workspace.code-workspace
 compile_commands.json
 .idea
+
+#
+# macOS
+#
+
+.DS_Store
+._.git


### PR DESCRIPTION
Adds `._.git` and `.DS_Store` to gitignore so I don't have to rm them all the time 😆 