### PR TITLE
Rewrite 'unique username system', removing libbsd dependency

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -19,31 +19,27 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Clone json-c
-      run: git clone https://github.com/json-c/json-c.git
-    - name: Build & Install json-c
-      run: mkdir json-c-build && cd json-c-build && cmake ../json-c && make && sudo make install
+      - uses: actions/checkout@v3
 
-    - name: Install bsd/string
-      run: sudo apt install libbsd-dev
-      
-    - name: Install enet
-      run: sudo apt install libenet-dev
+      - name: Clone json-c
+        run: git clone https://github.com/json-c/json-c.git
+      - name: Build & Install json-c
+        run: mkdir json-c-build && cd json-c-build && cmake ../json-c && make && sudo make install
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      - name: Install enet
+        run: sudo apt install libenet-dev
 
-    - name: Build
-      # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
-    - name: Test
-      working-directory: ${{github.workspace}}/build
-      # Execute tests defined by the CMake configuration.  
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest -C ${{env.BUILD_TYPE}}
-      
+      - name: Build
+        # Build your program with the given configuration
+        run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C ${{env.BUILD_TYPE}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,10 +32,6 @@ target_link_libraries(SpadesX
         Threads::Threads
 )
 
-if (UNIX)
-    target_link_libraries(SpadesX PRIVATE bsd)
-endif()
-
 add_subdirectory(Source)
 
 set_target_properties(SpadesX Util Server

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN     apk add --no-cache \
         cmake \
         gcc \
         json-c-dev \
-        libbsd-dev \
-        libbsd-static \
         libc-dev \
         make \
         musl-dev \
@@ -19,8 +17,7 @@ RUN     apk add --no-cache \
         readline-static \
         zlib-dev \
         zlib-static; \
-        mkdir /app; \
-        sed -i 's/\#include <bsd\/sys\/cdefs.h>/\#define __BEGIN_DECLS\n\#define __END_DECLS\n\#define __GLIBC_PREREQ(x,y) 0/' /usr/include/bsd/string.h
+        mkdir /app
 
 COPY    . /usr/src/spadesx
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Otherwise, be sure to install the development versions of those:
 * [zlib](https://github.com/madler/zlib)
 * [json-c](https://github.com/json-c/json-c)
 * [libreadline](https://tracker.debian.org/pkg/readline)
-* [libbsd](https://tracker.debian.org/pkg/libbsd) (Only on some systems)
 
 #### Docker
 

--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -1,3 +1,4 @@
+#include "Server/Structs/PlayerStruct.h"
 #include <Server/Packets/Packets.h>
 #include <Server/ParseConvert.h>
 #include <Server/Server.h>
@@ -93,7 +94,7 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
 
     while (unwantedNames[index] != NULL) {
         if (strstr(lowerCaseName, unwantedNames[index]) != NULL &&
-            strcmp(unwantedNames[index], strstr(lowerCaseName, unwantedNames[index])) == 0)
+            strncmp(unwantedNames[index], strstr(lowerCaseName, unwantedNames[index]), PLAYER_NAME_STRLEN) == 0)
         {
             snprintf(player->name, strlen("Deuce") + 1, "Deuce");
             free(lowerCaseName);
@@ -119,7 +120,7 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
                 continue;
             }
 
-            if (strcmp(new_name, connected_player->name) == 0) {
+            if (strncmp(new_name, connected_player->name, PLAYER_NAME_STRLEN) == 0) {
                 // found match
                 found_match = 1;
             }
@@ -130,7 +131,6 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
             break;
         }
 
-        new_name[0] = '\0';
         strncpy(new_name, player->name, PLAYER_NAME_STRLEN);
         new_name[PLAYER_NAME_STRLEN] = '\0';
         

--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -110,7 +110,8 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
     int       found_match = 0;
     player_t *connected_player, *tmp;
     char      new_name[PLAYER_NAME_STRLEN + 1] = "";
-    strcpy(new_name, player->name);
+    strncpy(new_name, player->name, PLAYER_NAME_STRLEN);
+    new_name[PLAYER_NAME_STRLEN] = '\0';
     while (1) {
         found_match = 0;
         HASH_ITER(hh, server->players, connected_player, tmp)
@@ -132,7 +133,8 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
         }
 
         new_name[0] = '\0';
-        strcpy(new_name, player->name);
+        strncpy(new_name, player->name, PLAYER_NAME_STRLEN);
+        new_name[PLAYER_NAME_STRLEN] = '\0';
         
         char id_str[4];
         snprintf(id_str, 4, "%d", player->id + 15);
@@ -146,7 +148,8 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
         strncat(new_name, id_str, id_len);
     }
     player->name[0] = '\0';
-    strcpy(player->name, new_name);
+    strncpy(player->name, new_name, PLAYER_NAME_STRLEN);
+    player->name[PLAYER_NAME_STRLEN] = '\0';
 
     set_default_player_ammo(player);
     player->state = STATE_SPAWNING;

--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -11,8 +11,6 @@
 #include <Util/Weapon.h>
 #include <ctype.h>
 
-#define PLAYER_NAME_STRLEN 16
-
 void send_existing_player(server_t* server, player_t* receiver, player_t* existing_player)
 {
     if (server->protocol.num_players == 0) {

--- a/Source/Server/Packets/ExistingPlayer.c
+++ b/Source/Server/Packets/ExistingPlayer.c
@@ -61,7 +61,7 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
     uint32_t length  = stream_left(data);
     uint8_t  invName = 0;
     if (length > PLAYER_NAME_STRLEN) {
-        LOG_WARNING("Name of player %d is too long. Cutting", player->id);
+        LOG_WARNING("Name of player %u is too long. Cutting", player->id);
         length = PLAYER_NAME_STRLEN;
     } else {
         player->name[length] = '\0';
@@ -137,7 +137,7 @@ void receive_existing_player(server_t* server, player_t* player, stream_t* data)
         new_name[PLAYER_NAME_STRLEN] = '\0';
         
         char id_str[4];
-        snprintf(id_str, 4, "%d", player->id + 15);
+        snprintf(id_str, 4, "%u", player->id + 15);
 
         size_t name_len = strlen(new_name);
         size_t id_len = strlen(id_str);

--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -266,7 +266,7 @@ void init_player(server_t*  server,
     player->is_invisible = 0;
     player->kills        = 0;
     player->deaths       = 0;
-    memset(player->name, 0, 17);
+    memset(player->name, 0, PLAYER_NAME_STRLEN + 1);
     memset(player->os_info, 0, 255);
 }
 

--- a/Source/Server/Structs/PlayerStruct.h
+++ b/Source/Server/Structs/PlayerStruct.h
@@ -15,6 +15,8 @@
 #include <enet/enet.h>
 #include <stdint.h>
 
+#define PLAYER_NAME_STRLEN 16
+
 typedef struct player
 {
     UT_hash_handle           hh;
@@ -81,7 +83,7 @@ typedef struct player
     uint8_t                  airborne;
     uint8_t                  wade;
     uint8_t                  next_shot_invalid;
-    char                     name[17];
+    char                     name[PLAYER_NAME_STRLEN + 1];
     char                     os_info[255];
 } player_t;
 


### PR DESCRIPTION
The code used to ensure usernames are unique for online players has been largely rewritten in this PR.

The major takeaways are:

- This PR aims to resolve #72; it appears to have no trouble modifying players' usernames to be unique regardless of the length of their desired name or their player ID as a string.

- Removed use case of `libbsd`, as this new version does not use `strlcat`.
    - Some other cleanup may be needed with CMake and documentation to finish removing this now-unused dependency.

- I'm almost certain there is a lot to improve with this code - C strings are my greatest weakness, lol. Please lend a hand in updating the code as you see fit.
    - I'm particularly worried about the use of standard string functions that aren't aware of a max bound they should restrict themselves to. Though, if they're not needed, then they're not needed - I'll leave this to the professionals to decide.

If you see this PR in a 'ready for review' state, it's ready for review + merge if you want. If it's a draft, I'm still making changes, feel free to ask for an update.

Thanks

## To-Do List

- [x] Ready for review / merge