### PR TITLE
Implemented water damages. Close #49

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install enet
         run: sudo apt install libenet-dev
 
+      - name: Install readline
+        run: sudo apt install libreadline-dev
+
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/Resources/maps/Border_Hallway/Border_Hallway.toml
+++ b/Resources/maps/Border_Hallway/Border_Hallway.toml
@@ -9,6 +9,12 @@ hostile. Part of SpadesX entry maps for hallway
 
 fog_color = [128, 232, 255]
 
+# Water damage configuration (optional)
+# Set water_damage_enabled to 1 to enable water damage
+# water_damage_per_second specifies the damage dealt every second while in water
+water_damage_enabled = 1
+water_damage_per_second = 5
+
 [spawnpoints]
 team1 = { start = [64, 233,  59], end = [118, 287, 59] }
 team2 = { start = [393, 225, 59], end = [447, 278, 59] }

--- a/Resources/maps/Border_Hallway/Border_Hallway.toml
+++ b/Resources/maps/Border_Hallway/Border_Hallway.toml
@@ -10,9 +10,9 @@ hostile. Part of SpadesX entry maps for hallway
 fog_color = [128, 232, 255]
 
 # Water damage configuration (optional)
-# Set water_damage_enabled to 1 to enable water damage
+# Set water_damage_enabled to true to enable water damage
 # water_damage_per_second specifies the damage dealt every second while in water
-water_damage_enabled = 1
+water_damage_enabled = true
 water_damage_per_second = 5
 
 [spawnpoints]

--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -91,6 +91,16 @@ void update_movement_and_grenades(server_t* server)
                 vector3f_t zero = {0, 0, 0};
                 send_set_hp(server, player, player, falldamage, 0, 4, 5, 0, zero);
             }
+
+            // Apply water damage if enabled
+            if (server->protocol.water_damage_enabled && player->wade && player->alive) {
+                uint64_t time = get_nanos();
+                if (time - player->timers.since_last_water_damage >= NANO_IN_SECOND) {
+                    vector3f_t zero = {0, 0, 0};
+                    send_set_hp(server, player, player, server->protocol.water_damage, 0, 4, 5, 0, zero);
+                    player->timers.since_last_water_damage = time;
+                }
+            }
         }
         handle_grenade(server, player);
     }
@@ -238,6 +248,7 @@ void init_player(server_t*  server,
     player->timers.time_since_last_wu            = 0;
     player->timers.since_last_weapon_input       = 0;
     player->timers.since_last_intel_tent_check   = 0;
+    player->timers.since_last_water_damage       = 0;
     player->told_to_master                       = 0;
     player->hp                                   = 100;
     player->blocks                               = 50;

--- a/Source/Server/Player.c
+++ b/Source/Server/Player.c
@@ -93,11 +93,11 @@ void update_movement_and_grenades(server_t* server)
             }
 
             // Apply water damage if enabled
-            if (server->protocol.water_damage_enabled && player->wade && player->alive) {
+            if (server->protocol.gamemode.water_damage_enabled && player->wade && player->alive) {
                 uint64_t time = get_nanos();
                 if (time - player->timers.since_last_water_damage >= NANO_IN_SECOND) {
                     vector3f_t zero = {0, 0, 0};
-                    send_set_hp(server, player, player, server->protocol.water_damage, 0, 4, 5, 0, zero);
+                    send_set_hp(server, player, player, server->protocol.gamemode.water_damage, 0, 4, 5, 0, zero);
                     player->timers.since_last_water_damage = time;
                 }
             }

--- a/Source/Server/Server.c
+++ b/Source/Server/Server.c
@@ -174,7 +174,7 @@ static void _server_init(server_t*   server,
     /* [water_damage] */
     uint8_t water_damage_enabled;
     uint8_t water_damage_per_second;
-    TOMLH_GET_INT(map_table, water_damage_enabled, "water_damage_enabled", 0, 1);
+    TOMLH_GET_BOOL(map_table, water_damage_enabled, "water_damage_enabled", 0, 1);
     TOMLH_GET_INT(map_table, water_damage_per_second, "water_damage_per_second", 5, 1);
 
     /* [spawnpoints] */

--- a/Source/Server/Server.c
+++ b/Source/Server/Server.c
@@ -171,6 +171,12 @@ static void _server_init(server_t*   server,
     TOMLH_GET_INT_ARRAY(map_table, map_size, "map_size", 3, ((int[]){512, 512, 64}), 1);
     TOMLH_GET_INT(map_table, capture_limit, "capture_limit", server->capture_limit, 1);
 
+    /* [water_damage] */
+    uint8_t water_damage_enabled;
+    uint8_t water_damage_per_second;
+    TOMLH_GET_INT(map_table, water_damage_enabled, "water_damage_enabled", 0, 1);
+    TOMLH_GET_INT(map_table, water_damage_per_second, "water_damage_per_second", 5, 1);
+
     /* [spawnpoints] */
     toml_table_t* spawnpoints_table;
     toml_table_t* team1_spawnpoints_table;
@@ -246,6 +252,9 @@ static void _server_init(server_t*   server,
     server->protocol.name_team[0][strlen(team1Name)] = '\0';
     server->protocol.name_team[1][strlen(team2Name)] = '\0';
     server->protocol.gamemode.score_limit = capture_limit;
+
+    server->protocol.water_damage_enabled = water_damage_enabled;
+    server->protocol.water_damage         = water_damage_per_second;
 
     memcpy(server->server_name, serverName, strlen(serverName));
     server->server_name[strlen(serverName)] = '\0';

--- a/Source/Server/Server.c
+++ b/Source/Server/Server.c
@@ -253,8 +253,8 @@ static void _server_init(server_t*   server,
     server->protocol.name_team[1][strlen(team2Name)] = '\0';
     server->protocol.gamemode.score_limit = capture_limit;
 
-    server->protocol.water_damage_enabled = water_damage_enabled;
-    server->protocol.water_damage         = water_damage_per_second;
+    server->protocol.gamemode.water_damage_enabled = water_damage_enabled;
+    server->protocol.gamemode.water_damage         = water_damage_per_second;
 
     memcpy(server->server_name, serverName, strlen(serverName));
     server->server_name[strlen(serverName)] = '\0';

--- a/Source/Server/Structs/GamemodeStruct.h
+++ b/Source/Server/Structs/GamemodeStruct.h
@@ -13,6 +13,9 @@ typedef struct gamemode_vars
     vector3f_t   base[2];
     uint8_t      player_intel_team[2];
     uint8_t      intel_held[2];
+    // water damage
+    uint8_t      water_damage_enabled;
+    uint8_t      water_damage;
 } gamemode_vars_t;
 
 #endif

--- a/Source/Server/Structs/ProtocolStruct.h
+++ b/Source/Server/Structs/ProtocolStruct.h
@@ -20,9 +20,6 @@ typedef struct protocol
     // respawn area
     quad3d_t spawns[2];
     uint32_t input_flags;
-    // water damage
-    uint8_t water_damage_enabled;
-    uint8_t water_damage;
 } protocol_t;
 
 #endif

--- a/Source/Server/Structs/ProtocolStruct.h
+++ b/Source/Server/Structs/ProtocolStruct.h
@@ -20,6 +20,9 @@ typedef struct protocol
     // respawn area
     quad3d_t spawns[2];
     uint32_t input_flags;
+    // water damage
+    uint8_t water_damage_enabled;
+    uint8_t water_damage;
 } protocol_t;
 
 #endif

--- a/Source/Server/Structs/TimerStruct.h
+++ b/Source/Server/Structs/TimerStruct.h
@@ -25,6 +25,7 @@ typedef struct timers
     uint64_t since_periodic_message;
     uint64_t since_last_intel_tent_check;
     uint64_t during_noclip_period;
+    uint64_t since_last_water_damage;
 } timers_t;
 
 typedef struct global_timers


### PR DESCRIPTION
Fixes:
- Implemented water damages.

Changes proposed in this pull request:
- Added configurable water damage system that allows map administrators to enable water damage per map
- Added water_damage_enabled and water_damage fields to protocol_t struct to store water damage configuration
- Added since_last_water_damage timer to timers_t struct to track damage intervals
- Modified Server.c to read water damage settings from map TOML files (water_damage_enabled and water_damage_per_second)
- Implemented water damage logic in update_movement_and_grenades() that applies configurable damage every second when players are in water
- Updated example map configuration file (enabled water damages by default)

I'll be pleased to modify my PR if needed :)